### PR TITLE
fix:서버와의 userInfo 교류를 위한 수정 및 리팩토링

### DIFF
--- a/FE_LXD/src/App.tsx
+++ b/FE_LXD/src/App.tsx
@@ -11,15 +11,14 @@ import WritingPage from "./pages/Diary/WritingPage";
 import DiaryPage from "./pages/Diary/DiaryPage";
 import LoginPage from "./pages/Login/LoginPage";
 import NotFoundPage from "./pages/Etc/NotFoundPage";
-import SignupPage from "./pages/Login/SignupPage";
 import FriendsListPage from "./pages/Friends/FriendsListPage";
 import CorrectionsPage from "./pages/Corrections/CorrectionsPage";
-import ProfilePage from "./pages/Login/ProfilePage";
 import EditProfilePage from "./pages/Navbar/EditProfilePage";
 import SettingsPage from "./pages/Settings/SettingsPage";
 import FeedPage from "./pages/Feed/FeedPage";
 import DiaryDetailPage from "./pages/Diary/DiaryDetailPage";
 import ProvideCorrections from "./components/Diary/ProvideCorrections";
+import SignupFlow from "./pages/Login/SignupFlow";
 
 const publicRoutes: RouteObject[] = [
   {
@@ -28,8 +27,7 @@ const publicRoutes: RouteObject[] = [
     // errorElement: <ErrorPage />,
     children: [
       { index: true, element: <LoginPage /> },
-      { path: "signup", element: <SignupPage /> },
-      { path: "signup/profile", element: <ProfilePage /> },
+      { path: "signup/*", element: <SignupFlow /> },
 
     ],
   },

--- a/FE_LXD/src/components/Login/LangOptionsButton.tsx
+++ b/FE_LXD/src/components/Login/LangOptionsButton.tsx
@@ -23,10 +23,16 @@ const LangOptionsButton = ({
           type="button"
           onClick={() => setIsOpen(!isOpen)}
           className="w-[250px] h-[55px] px-[32px] py-[16px] border rounded-md 
-              border-gray-300 bg-gray-50 text-gray-500 text-body1 
-              focus:outline-none"
+              border-gray-300 bg-gray-50 focus:outline-none"
         >
-          <span className="block truncate text-left text-body1 text-gray-400">
+          <span
+            className={`block truncate text-left text-body1 
+            ${
+              selected === "ko" || selected === "en"
+                ? "text-black"
+                : "text-gray-500"
+            }`}
+          >
             {selected === "ko"
               ? "한국어"
               : selected === "en"

--- a/FE_LXD/src/pages/Login/LoginPage.tsx
+++ b/FE_LXD/src/pages/Login/LoginPage.tsx
@@ -27,7 +27,6 @@ const LoginPage = () => {
     items-center justify-center space-y-12 px-4"
     >
       <TopLangOptionsButton />
-
       <header className="flex flex-col items-center space-y-8">
         <img src="images/LXD_logo.svg" />
         <img src="images/language_x_diary.svg" />

--- a/FE_LXD/src/pages/Login/ProfilePage.tsx
+++ b/FE_LXD/src/pages/Login/ProfilePage.tsx
@@ -7,54 +7,78 @@ import IDButton from "../../components/Login/IDButton";
 import SignupButton from "../../components/Login/SignupButton";
 import { useNavigate } from "react-router-dom";
 import TitleHeader from "../../components/Common/TitleHeader";
+import { isIdValid, isNicknameValid } from "../../utils/validate";
+import type { SignupFlowProps } from "./SignupFlow";
+import axios from "axios";
 
-const ProfilePage = () => {
-  const [userInfo, setUserInfo] = useState({
-    lang: "ko",
-    nativeLang: "",
-    studyLang: "",
-    id: "",
-    nickname: "",
-  });
+interface ProfilePageProps {
+  userInfo: SignupFlowProps;
+  setUserInfo: React.Dispatch<React.SetStateAction<SignupFlowProps>>;
+}
+
+const ProfilePage = ({ userInfo, setUserInfo }: ProfilePageProps) => {
   const [idTouched, setIdTouched] = useState(false);
   const [idChecked, setIdChecked] = useState(false);
-  const [preview, setPreview] = useState<string | null>(null);
+  const [nicknameTouched, setNicknameTouched] = useState(false);
+  const [isIdAvailable, setIsIdAvailable] = useState<boolean | null>(null);
   const navigate = useNavigate();
+
+  // 모킹 함수 (나중에 삭제)
+  async function fakeIdCheck(
+    id: string,
+    mode: "available" | "taken" | "random" = "available"
+  ): Promise<{ ok: boolean }> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        if (mode === "random") {
+          const available = Math.random() > 0.5;
+          resolve({ ok: available });
+          return;
+        }
+        resolve({ ok: mode === "available" });
+      }, 500);
+    });
+  }
+
+  const handleIDCheck = async () => {
+    setIdTouched(true);
+    setIdChecked(true);
+    try {
+      // 여기에 아이디 중복 확인 API 요청이 들어감 (axios)
+      const response = await fakeIdCheck(userInfo.id, "random");
+      if (!response.ok) {
+        setIsIdAvailable(false); // 이미 사용 중
+        console.log("아이디 중복됨");
+      } else {
+        setIsIdAvailable(true); // 사용 가능
+        console.log("사용 가능한 아이디");
+      }
+    } catch (err) {
+      alert("아이디 확인 중 오류가 발생했습니다");
+      console.error("ID 중복 확인 실패:", err);
+    }
+  };
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       const imageURL = URL.createObjectURL(file);
-      setPreview(imageURL);
+      setUserInfo((prev) => ({ ...prev, preview: imageURL }));
     }
   };
-  const handleIDCheck = () => {
-    // 아이디 중복 확인 API 나중에 작성 예정
-    // 유효하면 밑에 민트글씨 뜨게하기
-    setIdTouched(true);
-    setIdChecked(true);
-    console.log("아이디 중복 확인 요청");
-  };
-
-  const isValid = () => {
-    const { id, nickname, nativeLang, studyLang } = userInfo;
-    const isIdValid = id.trim().length >= 6; // 아이디 유효성, 중복확인까지 완료해야함, 나중에 수정
-    const isNicknameValid = nickname.trim() !== ""; // 닉네임 유효성, 나중에 수정
-    const isLangValid = nativeLang !== "" && studyLang !== "";
-
-    return isIdValid && isNicknameValid && isLangValid;
-  };
-  const handleCompleteSignup = () => {
-    if (!isValid()) return;
-    // 회원 데이터 보내기 API
-    console.log(userInfo.id, userInfo.nickname, userInfo.nativeLang, userInfo.studyLang)
-    alert("회원가입 완료");
-    navigate("/home");
+  const handleRemoveImage = () => {
+    setUserInfo((prev) => ({ ...prev, preview: "" }));
   };
 
   const handleInputChange = (key: keyof typeof userInfo, value: string) => {
     setUserInfo((prev) => ({ ...prev, [key]: value }));
+    // 아이디 입력이 바뀌면 중복확인 상태 초기화
+    if (key === "id") {
+      setIdChecked(false);
+      setIsIdAvailable(false);
+    }
   };
+
   const handleNativeLangSelect = (lang: string) => {
     setUserInfo((prev) => ({
       ...prev,
@@ -67,8 +91,39 @@ const ProfilePage = () => {
     setUserInfo((prev) => ({
       ...prev,
       studyLang: lang,
-      nativeLang: lang === "ko" ? "en" : "ko",
     }));
+  };
+
+  const isAllValid = () => {
+    const { nativeLang, studyLang } = userInfo;
+    const _isIdValid = isIdValid(userInfo.id) && isIdAvailable === true;
+    const _isNicknameValid = isNicknameValid(userInfo.nickname);
+    const _isLangValid = nativeLang !== "" && studyLang !== "";
+
+    return _isIdValid && _isNicknameValid && _isLangValid;
+  };
+
+  const handleCompleteSignup = async () => {
+    const payload = {
+      email: userInfo.email,
+      password: userInfo.password,
+      username: userInfo.id,
+      nickname: userInfo.nickname,
+      profileImg: userInfo.profileImg,
+      nativeLang: userInfo.nativeLang,
+      studyLang: userInfo.studyLang,
+      isPrivacy: userInfo.isPrivacy,
+    };
+
+    try {
+      const response = await axios.post("/members/join", payload);
+      console.log("회원가입 성공", response.data);
+      alert("회원가입 성공")
+    } catch (err) {
+      console.error("회원가입 실패:", err);
+      alert("회원가입 실패, 다시 시도해주세요")
+    }
+    navigate("/home");
   };
 
   return (
@@ -76,10 +131,7 @@ const ProfilePage = () => {
       className="flex flex-col min-h-screen
     items-center justify-center px-4"
     >
-      <TopLangOptionsButton
-        selected={userInfo.lang}
-        onSelect={(val) => handleInputChange("lang", val)}
-      />
+      <TopLangOptionsButton />
       <div className="w-[545px] items-left space-y-11">
         <section className="h-[110px] space-y-12">
           <PrevButton navigateURL="/home/signup" />
@@ -88,21 +140,34 @@ const ProfilePage = () => {
 
         <section className="w-full flex items-center justify-center">
           {/* 사진 추가 프로필 */}
-          <label
-            htmlFor="profile-upload"
-            className="w-[145px] h-[145px] flex items-center justify-center 
+          <div className="relative">
+            <label
+              htmlFor="profile-upload"
+              className="w-[145px] h-[145px] flex items-center justify-center 
             border border-gray-400 bg-gray-300 text-body2 text-gray-600 
             underline underline-offset-2 rounded-full cursor-pointer"
-          >
-            {preview ? (
-              <img
-                src={preview}
-                alt="profile-preview"
-                className="w-full h-full object-cover rounded-full"
+            >
+              {userInfo.profileImg ? (
+                <img
+                  src={userInfo.profileImg}
+                  alt="profileImg"
+                  className="w-full h-full object-cover rounded-full"
+                />
+              ) : (
+                <span>사진 추가</span>
+              )}
+            </label>
+
+            {userInfo.profileImg && (
+              <button
+                type="button"
+                onClick={handleRemoveImage}
+                className="bg-[url('/images/x_icon.svg')]
+                bg-no-repeat bg-center bg-contain absolute top-1 right-4 w-5 h-5  
+                 flex items-center justify-center cursor-pointer"
               />
-            ) : (
-              <span>사진 추가</span>
             )}
+
             <input
               type="file"
               id="profile-upload"
@@ -110,7 +175,7 @@ const ProfilePage = () => {
               onChange={handleImageChange}
               className="hidden"
             />
-          </label>
+          </div>
         </section>
 
         <form className="w-full space-y-8">
@@ -125,20 +190,47 @@ const ProfilePage = () => {
                   onBlur={() => setIdTouched(true)}
                 />
               </div>
-              <IDButton name="중복확인" onClick={handleIDCheck} />
+              <IDButton
+                name="중복확인"
+                onClick={handleIDCheck}
+                disabled={!isIdValid(userInfo.id)}
+              />
             </div>
-            {idTouched && idChecked && userInfo.id.trim() !== "" && (
-              <span className="text-body2 text-mint-500">
-                사용가능한 아이디입니다
-              </span>
+            {idTouched && userInfo.id.trim() !== "" && (
+              <>
+                {!isIdValid(userInfo.id) ? (
+                  <span className="text-body2 text-red-500">
+                    영어 소문자와 특수기호(-._)만 사용가능 하며, 2자 이상
+                    입력해야 합니다
+                  </span>
+                ) : idChecked && isIdAvailable === true ? (
+                  <span className="text-body2 text-mint-500">
+                    사용가능한 아이디입니다
+                  </span>
+                ) : idChecked && isIdAvailable === false ? (
+                  <span className="text-body2 text-red-500">
+                    사용할 수 없는 아이디입니다
+                  </span>
+                ) : null}
+              </>
             )}
           </div>
-          <FormInput
-            name="닉네임"
-            placeholder="닉네임을 입력해주세요"
-            input={userInfo.nickname}
-            onChange={(e) => handleInputChange("nickname", e.target.value)}
-          />
+          <div className="flex flex-col space-y-2">
+            <FormInput
+              name="닉네임"
+              placeholder="닉네임을 입력해주세요"
+              input={userInfo.nickname}
+              onChange={(e) => handleInputChange("nickname", e.target.value)}
+              onBlur={() => setNicknameTouched(true)}
+            />
+            {nicknameTouched &&
+              userInfo.nickname.trim() !== "" &&
+              !isNicknameValid(userInfo.nickname) && (
+                <span className="text-body2 text-red-500">
+                  1자 이상 40자 이내의 영어 또는 한글로 작성해주세요
+                </span>
+              )}
+          </div>
           <div className="flex justify-between">
             <LangOptionsButton
               name="모국어 / 주사용 언어"
@@ -157,7 +249,7 @@ const ProfilePage = () => {
           <SignupButton
             name="가입완료"
             onClick={handleCompleteSignup}
-            disabled={!isValid()}
+            disabled={!isAllValid()}
           />
         </section>
       </div>

--- a/FE_LXD/src/pages/Login/SignupFlow.tsx
+++ b/FE_LXD/src/pages/Login/SignupFlow.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Route, Routes } from "react-router-dom";
+import SignupPage from "./SignupPage";
+import ProfilePage from "./ProfilePage";
+
+export interface SignupFlowProps {
+  email: string;
+  password: string;
+  checkPassword: string;
+  isPrivacy: boolean;
+  id: string;
+  nickname: string;
+  profileImg: string;
+  nativeLang: string;
+  studyLang: string;
+}
+
+const SignupFlow = () => {
+  const [userInfo, setUserInfo] = useState<SignupFlowProps>({
+    email: "",
+    password: "",
+    checkPassword: "",
+    isPrivacy: false,
+    id: "",
+    nickname: "",
+    profileImg: "",
+    nativeLang: "",
+    studyLang: "",
+  });
+
+  return (
+    <Routes>
+      <Route
+        index
+        element={<SignupPage userInfo={userInfo} setUserInfo={setUserInfo} />}
+      />
+      <Route
+        path="profile"
+        element={<ProfilePage userInfo={userInfo} setUserInfo={setUserInfo} />}
+      />
+    </Routes>
+  );
+};
+
+export default SignupFlow;

--- a/FE_LXD/src/pages/Login/SignupPage.tsx
+++ b/FE_LXD/src/pages/Login/SignupPage.tsx
@@ -11,31 +11,31 @@ import {
   isPasswordMatch,
   isPasswordValid,
 } from "../../utils/validate";
+import type { SignupFlowProps } from "./SignupFlow";
 
-const SignupPage = () => {
-  const [userInfo, setUserInfo] = useState({
-    lang: "ko",
-    email: "",
-    password: "",
-    checkPassword: "",
-  });
+interface SignupPageProps {
+  userInfo: SignupFlowProps;
+  setUserInfo: React.Dispatch<React.SetStateAction<SignupFlowProps>>;
+}
+
+const SignupPage = ({ userInfo, setUserInfo }: SignupPageProps) => {
   const [emailVerified, setEmailVerified] = useState(false);
   const [emailTouched, setEmailTouched] = useState(false);
   const [passwordTouched, setPasswordTouched] = useState(false);
   const [checkPasswordTouched, setCheckPasswordTouched] = useState(false);
-  const [agreed, setAgreed] = useState(false);
   const navigate = useNavigate();
 
-  // 모킹 함수 (나중에 삭제)
+  // 이메일 인증 모킹 함수 (나중에 삭제)
   async function fakeEmailVerify(email: string) {
     return new Promise<{ ok: boolean }>((resolve) => {
       setTimeout(() => resolve({ ok: true }), 1000);
+      console.log(email)
     });
   }
 
   const handleEmailCheck = async () => {
     try {
-      // 여기에 실제 API 요청이 들어감 (나중에 axios로 대체)
+      // 여기에 이메일 인증 API 요청이 들어감 (나중에 axios로 대체)
       const response = await fakeEmailVerify(userInfo.email);
 
       if (!response.ok) {
@@ -50,6 +50,14 @@ const SignupPage = () => {
     }
   };
 
+  const handleInputChange = (key: keyof typeof userInfo, value: string) => {
+    setUserInfo((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleIsPrivacy = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setUserInfo((prev) => ({ ...prev, isPrivacy: e.target.checked }));
+  };
+
   const isAllValid = () => {
     const _isEmailValid = isEmailValid(userInfo.email);
     const _isPasswordValid = isPasswordValid(userInfo.password);
@@ -58,16 +66,11 @@ const SignupPage = () => {
       userInfo.checkPassword
     );
 
-    return _isEmailValid && _isPasswordValid && _isPasswordChecked && agreed;
-  };
-
-  const handleInputChange = (key: keyof typeof userInfo, value: string) => {
-    setUserInfo((prev) => ({ ...prev, [key]: value }));
+    return _isEmailValid && _isPasswordValid && _isPasswordChecked && userInfo.isPrivacy;
   };
 
   const handleNextPage = () => {
     if (!isAllValid()) return;
-    // 서버로 가입 정보 전송해야함, 나중에 수정
     console.log(userInfo.email, userInfo.password);
     navigate("profile");
   };
@@ -77,10 +80,7 @@ const SignupPage = () => {
       className="flex flex-col min-h-screen
     items-center justify-center px-4"
     >
-      <TopLangOptionsButton
-        selected={userInfo.lang}
-        onSelect={(val) => handleInputChange("lang", val)}
-      />
+      <TopLangOptionsButton />
       <div className="w-[545px] items-left space-y-11">
         <section className="h-[110px] space-y-12">
           <PrevButton navigateURL="/home" />
@@ -108,6 +108,11 @@ const SignupPage = () => {
             {emailTouched && !isEmailValid(userInfo.email) && (
               <span className="text-body2 text-red-500">
                 유효하지 않은 이메일입니다
+              </span>
+            )}
+            {emailTouched && isEmailValid(userInfo.email) && (
+              <span className="text-body2 text-mint-500">
+                사용가능한 이메일입니다
               </span>
             )}
           </div>
@@ -156,8 +161,8 @@ const SignupPage = () => {
           <label className="flex gap-2 items-center">
             <input
               type="checkbox"
-              checked={agreed}
-              onChange={(e) => setAgreed(e.target.checked)}
+              checked={userInfo.isPrivacy}
+              onChange={handleIsPrivacy}
               className="w-[19px] h-[19px]"
             />
             <span className="text-body1">

--- a/FE_LXD/src/utils/validate.ts
+++ b/FE_LXD/src/utils/validate.ts
@@ -11,7 +11,7 @@ export function isPasswordValid(password: string): boolean {
   const lowerCheck = /[a-z]/.test(password);
   const numberCheck = /[0-9]/.test(password);
   const specialCheck = /[!@#$%^&*(),.?":{}|<>]/.test(password);
-  
+
   return lengthCheck && upperCheck && lowerCheck && numberCheck && specialCheck;
 }
 
@@ -21,4 +21,17 @@ export function isPasswordMatch(
   checkPassword: string
 ): boolean {
   return password === checkPassword;
+}
+
+// 아이디 유효성 검사 함수: 영어 소문자, 숫자, 특수기호만. 2자이상. 공백 없음
+// 중복확인 API 거친 후 사용 가능할 때만 유효
+export function isIdValid(id: string): boolean {
+  const pattern = /^[a-z0-9._-]{2,}$/;
+  return pattern.test(id) && !/\s/.test(id);
+}
+
+// 닉네임 유효성 검사 함수: 영어 또는 한글. 1~40자 이하
+export function isNicknameValid(nickname: string) {
+  const pattern = /^[a-zA-Z가-힣]{1,40}$/;
+  return pattern.test(nickname);
 }


### PR DESCRIPTION
## 개요

기능 구현 :

회원가입 API에 있는 body로 userInfo 구성 수정.

[SignupFlow 라우트] : SignupPage -> ProfilePage 두 단계를 거치는 회원가입 과정에서, 가입완료 버튼을 눌렀을 때 userInfo를 모두 전달할 수 있도록 SignupFlow 라우트를 추가. 이곳에서 userInfo 상태관리 

```
<SignupFlow>
  ├── <SignupPage userInfo={userInfo} setUserInfo={setUserInfo} />
  └── <ProfilePage userInfo={userInfo} setUserInfo={setUserInfo} />
</SignupFlow>
```


## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
