### PR TITLE
친구 상태 훅 적용, 다이어리 보러가기 라우팅, UserDetailPage 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,7 +93,7 @@ const protectedRoutes: RouteObject[] = [
         element: <NotFoundPage />,
       },
       {
-        path: "/feed/:username/detail",
+        path: "/diaries/member/:memberId",
         element: <UserDetailPage />,
       },
     ],

--- a/src/components/Friends/ProfileView.tsx
+++ b/src/components/Friends/ProfileView.tsx
@@ -123,7 +123,7 @@ const ProfileView = ({
         )}
 
         <button
-          onClick={() => navigate("/feed/1", { state: { from: "profile" } })}
+          onClick={() => navigate(`/diaries/member/${user.id}`, { state: { from: "profile" } })}
           className="flex-1 py-3 rounded-xl bg-[#EDF3FE] text-[#618BFD] text-base font-semibold hover:bg-blue-100"
         >
           다이어리 보러가기

--- a/src/components/Friends/ProfileView.tsx
+++ b/src/components/Friends/ProfileView.tsx
@@ -4,19 +4,20 @@ import Avatar from "../Common/Avatar";
 import { useNavigate } from "react-router-dom";
 import { addRecentSearch } from "../../utils/types/recentSearch";
 import { postFriendRequest } from "../../apis/friend";
+import useFriendship from "../../hooks/queries/useFriendship"; // ✅ 추가
 
 interface ProfileViewProps {
   user: {
     name: string;
     username: string;
     image?: string;
-    isFriend: boolean;
+    isFriend: boolean;   // (과거 호환용) 훅 결과가 우선
     id: number;
   };
   onClose: () => void;
   onUnfriendClick: () => void;
   onAvatarClick: () => void;
-  isRequesting: boolean;
+  isRequesting: boolean; // (과거 호환용) 훅 결과가 우선
   onSendRequestClick: () => void;
 }
 
@@ -30,18 +31,31 @@ const ProfileView = ({
 }: ProfileViewProps) => {
   const navigate = useNavigate();
 
+  // ✅ 친구관계 상태 조회 (friend | pending | incoming | none)
+  const { state, isLoading, refetchAll } = useFriendship(user.id);
+
+  // 과거 프롭과 병합(훅 우선, 프롭은 fallback)
+  const mergedState =
+    isLoading ? "loading"
+    : state === "friend" || state === "pending" || state === "incoming" || state === "none"
+    ? state
+    : (user.isFriend ? "friend" : (isRequesting ? "pending" : "none"));
+
   useEffect(() => {
-    if (user?.username) {
-      addRecentSearch(user.username);
-    }
+    if (user?.username) addRecentSearch(user.username);
   }, [user?.username]);
 
   const handleSendRequest = async () => {
     try {
-      console.log("✅ 친구 요청 API 호출", user.id);
       await postFriendRequest({ receiverId: user.id });
-      onSendRequestClick(); // 상태 업데이트 요청
-    } catch (err) {
+      onSendRequestClick?.();
+      await refetchAll(); // ✅ 요청 후 최신 상태 반영
+    } catch (err: any) {
+      // 이미 보낸 요청(409)은 '요청중'으로 보이게 갱신
+      if (err?.response?.status === 409) {
+        await refetchAll();
+        return;
+      }
       console.error("❌ 친구 요청 실패:", err);
       alert("친구 요청에 실패했습니다.");
     }
@@ -63,39 +77,46 @@ const ProfileView = ({
             <div className="text-base text-gray-500">@{user.username}</div>
           </div>
         </div>
-        <button
-          className="text-gray-400 hover:text-gray-600 cursor-pointer"
-          onClick={onClose}
-        >
+        <button className="text-gray-400 hover:text-gray-600" onClick={onClose}>
           <X size={24} />
         </button>
       </div>
 
       <div className="px-8 mb-6 flex gap-4">
-        {/* 친구 or 요청 상태 버튼 */}
-        {user.isFriend ? (
+        {/* 버튼 상태 분기 */}
+        {mergedState === "loading" ? (
+          <button className="flex-1 py-3 rounded-xl bg-gray-100 text-gray-400" disabled>
+            로딩중…
+          </button>
+        ) : mergedState === "friend" ? (
           <button
-            className="flex-1 py-3 rounded-xl bg-[#3461F4] text-white text-base font-semibold hover:bg-blue-700 cursor-pointer"
+            className="flex-1 py-3 rounded-xl bg-[#3461F4] text-white text-base font-semibold hover:bg-blue-700"
             onClick={onUnfriendClick}
           >
             친구
           </button>
-        ) : isRequesting ? (
+        ) : mergedState === "pending" ? (
           <button
             disabled
             className="flex-1 py-3 rounded-xl bg-[#EDF3FE] text-[#618BFD] text-base font-semibold cursor-not-allowed flex items-center justify-center gap-2"
           >
-            <img
-              src="/images/requestingIcon.svg"
-              alt="요청중"
-              className="w-5 h-5"
-            />
+            <img src="/images/requestingIcon.svg" alt="요청중" className="w-5 h-5" />
             요청중
           </button>
+        ) : mergedState === "incoming" ? (
+          // 받은 요청 상태를 쓸 계획 없다면 이 블록은 제거해도 됨
+          <div className="flex-1 grid grid-cols-2 gap-3">
+            <button className="py-3 rounded-xl bg-[#3461F4] text-white font-semibold">
+              수락
+            </button>
+            <button className="py-3 rounded-xl bg-gray-100 text-gray-700 font-semibold">
+              거절
+            </button>
+          </div>
         ) : (
           <button
             onClick={handleSendRequest}
-            className="flex-1 py-3 rounded-xl bg-[#3461F4] text-white text-base font-semibold hover:bg-blue-700 cursor-pointer"
+            className="flex-1 py-3 rounded-xl bg-[#3461F4] text-white text-base font-semibold hover:bg-blue-700"
           >
             친구 요청하기
           </button>
@@ -103,7 +124,7 @@ const ProfileView = ({
 
         <button
           onClick={() => navigate("/feed/1", { state: { from: "profile" } })}
-          className="flex-1 py-3 rounded-xl bg-[#EDF3FE] text-[#618BFD] text-base font-semibold hover:bg-blue-100 cursor-pointer"
+          className="flex-1 py-3 rounded-xl bg-[#EDF3FE] text-[#618BFD] text-base font-semibold hover:bg-blue-100"
         >
           다이어리 보러가기
         </button>
@@ -124,11 +145,7 @@ const ProfileView = ({
           >
             <div className="flex flex-col gap-2 flex-1">
               <div className="flex gap-3 items-center mb-2">
-                <img
-                  src="/images/public_icon.svg"
-                  alt="전체 아이콘"
-                  className="h-6 w-auto"
-                />
+                <img src="/images/public_icon.svg" alt="전체 아이콘" className="h-6 w-auto" />
                 <p className="font-bold text-lg text-gray-900">
                   여름방학 일기 {3 - idx}일차
                 </p>
@@ -138,27 +155,15 @@ const ProfileView = ({
               </p>
               <div className="flex gap-6 text-sm text-gray-500 mt-3">
                 <div className="flex items-center gap-1">
-                  <img
-                    src="/images/emptycommentIcon.svg"
-                    alt="댓글"
-                    className="w-5 h-5"
-                  />
+                  <img src="/images/emptycommentIcon.svg" alt="댓글" className="w-5 h-5" />
                   <span>180</span>
                 </div>
                 <div className="flex items-center gap-1">
-                  <img
-                    src="/images/EmptyHeartIcon.svg"
-                    alt="좋아요"
-                    className="w-5 h-5"
-                  />
+                  <img src="/images/EmptyHeartIcon.svg" alt="좋아요" className="w-5 h-5" />
                   <span>89</span>
                 </div>
                 <div className="flex items-center gap-1">
-                  <img
-                    src="/images/emptycorrectionIcon.svg"
-                    alt="공유"
-                    className="w-5 h-5"
-                  />
+                  <img src="/images/emptycorrectionIcon.svg" alt="공유" className="w-5 h-5" />
                   <span>5</span>
                 </div>
               </div>

--- a/src/hooks/queries/useFriendship.ts
+++ b/src/hooks/queries/useFriendship.ts
@@ -12,7 +12,8 @@ type FriendshipState = "friend" | "pending" | "incoming" | "none";
 // 응답에서 배열 꺼내는 helper (undefined 안전)
 const pick = <T,>(arr: T[] | undefined | null) => (Array.isArray(arr) ? arr : []);
 
-const FRIEND_FETCH_SIZE = 100; // 첫 페이지만 크게 가져와도 충분하면 100 정도로
+// 첫 페이지만 크게 가져와도 충분하면 100 정도로
+const FRIEND_FETCH_SIZE = Number(process.env.REACT_APP_FRIEND_FETCH_SIZE) || 100;
 
 export default function useFriendship(targetMemberId: number) {
   // 1) 내 친구 목록

--- a/src/hooks/queries/useFriendship.ts
+++ b/src/hooks/queries/useFriendship.ts
@@ -1,0 +1,76 @@
+// src/hooks/queries/useFriendship.ts
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getFriends, getFriendRequests } from "../../apis/friend";
+import type {
+  FriendListResponseDTO,
+  FriendRequestListResponseDTO,
+} from "../../utils/types/friend";
+
+type FriendshipState = "friend" | "pending" | "incoming" | "none";
+
+// 응답에서 배열 꺼내는 helper (undefined 안전)
+const pick = <T,>(arr: T[] | undefined | null) => (Array.isArray(arr) ? arr : []);
+
+const FRIEND_FETCH_SIZE = 100; // 첫 페이지만 크게 가져와도 충분하면 100 정도로
+
+export default function useFriendship(targetMemberId: number) {
+  // 1) 내 친구 목록
+  const friendsQ = useQuery({
+    queryKey: ["friends", 1, FRIEND_FETCH_SIZE],
+    queryFn: () => getFriends(1, FRIEND_FETCH_SIZE),
+    // 필요한 부분만 select 해서 컴포넌트 렌더 최소화
+    select: (res: FriendListResponseDTO) =>
+      pick(res?.result?.friends?.contents).map((m) => ({
+        memberId: m.memberId,
+      })),
+  });
+
+  // 2) 내 친구 요청 목록 (보낸/받은)
+  const requestsQ = useQuery({
+    queryKey: ["friendRequests"],
+    queryFn: getFriendRequests,
+    select: (res: FriendRequestListResponseDTO) => ({
+      sent: pick(res?.result?.sentRequests?.contents).map((m) => ({
+        memberId: m.memberId,
+      })),
+      received: pick(res?.result?.receivedRequests?.contents).map((m) => ({
+        memberId: m.memberId,
+      })),
+    }),
+  });
+
+  // 3) 상태 계산
+  const { state, isFriend, isPendingSent, isPendingReceived } = useMemo(() => {
+    const uid = Number(targetMemberId);
+
+    const friends = friendsQ.data ?? [];
+    const sent = requestsQ.data?.sent ?? [];
+    const received = requestsQ.data?.received ?? [];
+
+    const isFriend = friends.some((f) => Number(f.memberId) === uid);
+    const isPendingSent = sent.some((s) => Number(s.memberId) === uid);        // 내가 보낸 요청 → "요청중"
+    const isPendingReceived = received.some((r) => Number(r.memberId) === uid); // 내가 받은 요청 → "수락/거절 가능"
+
+    let state: FriendshipState = "none";
+    if (isFriend) state = "friend";
+    else if (isPendingSent) state = "pending";
+    else if (isPendingReceived) state = "incoming"; // 필요 없으면 이 분기 삭제해도 됨
+
+    return { state, isFriend, isPendingSent, isPendingReceived };
+  }, [friendsQ.data, requestsQ.data, targetMemberId]);
+
+  const isLoading = friendsQ.isLoading || requestsQ.isLoading;
+  const refetchAll = async () => {
+    await Promise.all([friendsQ.refetch(), requestsQ.refetch()]);
+  };
+
+  return {
+    state,                 // "friend" | "pending" | "incoming" | "none"
+    isFriend,
+    isPendingSent,         // 내가 보낸 요청 여부
+    isPendingReceived,     // 내가 받은 요청 여부
+    isLoading,
+    refetchAll,
+  };
+}


### PR DESCRIPTION
- ProfileView에 useFriendship 훅 적용하여 친구 상태(friend, pending, incoming, none) 실시간 반영
- 친구 요청 시 409 Conflict 응답 처리 → 요청중 상태 표시
- App.tsx 라우트에 /diaries/member/:memberId 경로 추가
- "다이어리 보러가기" 버튼 클릭 시 해당 유저의 UserDetailPage로 이동하도록 수정
- ProfileView 하단의 더미 "최근 일기" 섹션 제거
- UserDetailPage에서 getUserDiaries API 기반 무한 스크롤로 실제 다이어리 목록 불러오기
- 새 훅 useFriendship.ts 추가 (queries/useFriendship.ts)
## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
