### PR TITLE
Bug/localstorageprofile

### DIFF
--- a/src/components/Friends/FriendListPanel.tsx
+++ b/src/components/Friends/FriendListPanel.tsx
@@ -4,10 +4,12 @@ import SearchBar from "./SearchBar";
 import FriendItem, { pickProfileImage } from "./FriendItem";
 import FriendListSkeleton from "./Skeleton/FriendListSkeleton";
 import {
-  getRecentSearches,
+  getRecentSearchesWithMeta,
   addRecentSearch,
   removeRecentSearch,
   clearRecentSearches,
+  updateRecentSearchMeta,
+  type RecentSearch,
 } from "../../utils/types/recentSearch";
 import useDebounce from "../../hooks/queries/useDebounce";
 import { searchFriends } from "../../apis/friend";
@@ -30,6 +32,7 @@ export interface FriendSearchItem {
   profileImageUrl?: string | null;
   profileImage?: string | null;
   profileUrl?: string | null;
+  profileImg?: string | null; // ✅ 백엔드 스펙 대응 (/members/profile 등)
 }
 
 interface FriendListPanelProps {
@@ -43,7 +46,7 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
   const [search, setSearch] = useState("");
   const [friends, setFriends] = useState<FriendSearchItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
 
   const debouncedSearch = useDebounce(search, 300);
 
@@ -68,22 +71,50 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
     fetch();
   }, [debouncedSearch]);
 
+  // 초기 로드: 최근검색 불러오기 + 이미지 비어있는 항목 메타 백필
   useEffect(() => {
-    setRecentSearches(getRecentSearches());
+    const items = getRecentSearchesWithMeta();
+    setRecentSearches(items);
+
+    // 이미지 없는 항목을 서버 재조회로 보정 (한 번만)
+    (async () => {
+      const need = items.filter((it) => !it.image);
+      if (need.length === 0) return;
+
+      for (const it of need) {
+        try {
+          const data = await searchFriends(it.username);
+          const found: FriendSearchItem | undefined =
+            data.result.members.contents.find(
+              (m: FriendSearchItem) => m.username === it.username,
+            );
+          if (!found) continue;
+
+          const img = found.profileImg || pickProfileImage(found);
+          const name = found.nickname;
+          updateRecentSearchMeta(it.username, img, name);
+        } catch {
+          // 무시하고 다음으로
+        }
+      }
+
+      setRecentSearches(getRecentSearchesWithMeta());
+    })();
   }, []);
 
   // ✅ username만 있는 경우도 서버에서 정보 조회
   const handleSelectFriend = async (username: string, userInfo?: FriendSearchItem) => {
-    addRecentSearch(username);
-    setRecentSearches(getRecentSearches());
-
     // 검색 결과에서 온 경우
     if (userInfo) {
+      const img = userInfo.profileImg || pickProfileImage(userInfo);
+      addRecentSearch(username, img, userInfo.nickname); // ✅ 이미지/닉네임 저장
+      setRecentSearches(getRecentSearchesWithMeta());
+
       const friend: Friend = {
         id: userInfo.memberId,
         name: userInfo.nickname,
         username: userInfo.username,
-        image: pickProfileImage(userInfo), // ✅ 보정된 이미지
+        image: img,
         isFriend: false,
       };
       onSelect(friend);
@@ -94,7 +125,7 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
     try {
       const data = await searchFriends(username);
       const found: FriendSearchItem | undefined = data.result.members.contents.find(
-        (member: FriendSearchItem) => member.username === username
+        (member: FriendSearchItem) => member.username === username,
       );
 
       if (!found) {
@@ -102,11 +133,15 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
         return;
       }
 
+      const img = found.profileImg || pickProfileImage(found);
+      addRecentSearch(found.username, img, found.nickname); // ✅ 메타 갱신
+      setRecentSearches(getRecentSearchesWithMeta());
+
       const friend: Friend = {
         id: found.memberId,
         name: found.nickname,
         username: found.username,
-        image: pickProfileImage(found), // ✅ 보정된 이미지
+        image: img,
         isFriend: false,
       };
 
@@ -119,7 +154,7 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
 
   const handleRemoveRecent = (username: string) => {
     removeRecentSearch(username);
-    setRecentSearches(getRecentSearches());
+    setRecentSearches(getRecentSearchesWithMeta());
   };
 
   const handleClearRecent = () => {
@@ -153,22 +188,24 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
                   key={friend.username}
                   name={friend.nickname}
                   username={friend.username}
-                  image={pickProfileImage(friend)}   
+                  // ✅ 검색 결과: 서버가 주는 profileImg 우선 사용, 없으면 보정
+                  image={friend.profileImg || pickProfileImage(friend)}
                   onClick={() => handleSelectFriend(friend.username, friend)}
                   isSelected={selectedUsername === friend.username}
                   showDelete={false}
                 />
               ))
-            : recentSearches.map((username) => (
+            : recentSearches.map((item) => (
                 <FriendItem
-                  key={username}
-                  name={username}
-                  username={username}
-                  image={""}
-                  onClick={() => handleSelectFriend(username)} // ✅ 재조회 트리거
-                  isSelected={selectedUsername === username}
+                  key={item.username}
+                  name={item.name ?? item.username}
+                  username={item.username}
+                  // ✅ 저장된 이미지 그대로 표시 (없으면 빈 문자열 → 컴포넌트에서 기본아바타)
+                  image={item.image ?? ""}
+                  onClick={() => handleSelectFriend(item.username)} // ✅ 재조회 트리거
+                  isSelected={selectedUsername === item.username}
                   showDelete
-                  onDelete={() => handleRemoveRecent(username)}
+                  onDelete={() => handleRemoveRecent(item.username)}
                 />
               ))}
         </ul>

--- a/src/components/Friends/FriendListPanel.tsx
+++ b/src/components/Friends/FriendListPanel.tsx
@@ -1,4 +1,3 @@
-// src/components/Friends/FriendListPanel.tsx
 import { useEffect, useState } from "react";
 import SearchBar from "./SearchBar";
 import FriendItem, { pickProfileImage } from "./FriendItem";
@@ -24,7 +23,7 @@ export interface Friend {
   isFriend: boolean;
 }
 
-// ✅ 응답 키가 달라도 안전하게 받도록 선택지 추가
+
 export interface FriendSearchItem {
   memberId: number;
   username: string;
@@ -32,7 +31,7 @@ export interface FriendSearchItem {
   profileImageUrl?: string | null;
   profileImage?: string | null;
   profileUrl?: string | null;
-  profileImg?: string | null; // ✅ 백엔드 스펙 대응 (/members/profile 등)
+  profileImg?: string | null;
 }
 
 interface FriendListPanelProps {
@@ -71,12 +70,12 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
     fetch();
   }, [debouncedSearch]);
 
-  // 초기 로드: 최근검색 불러오기 + 이미지 비어있는 항목 메타 백필
+  
   useEffect(() => {
     const items = getRecentSearchesWithMeta();
     setRecentSearches(items);
 
-    // 이미지 없는 항목을 서버 재조회로 보정 (한 번만)
+    
     (async () => {
       const need = items.filter((it) => !it.image);
       if (need.length === 0) return;
@@ -102,12 +101,12 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
     })();
   }, []);
 
-  // ✅ username만 있는 경우도 서버에서 정보 조회
+  // username만 있는 경우도 서버에서 정보 조회
   const handleSelectFriend = async (username: string, userInfo?: FriendSearchItem) => {
     // 검색 결과에서 온 경우
     if (userInfo) {
       const img = userInfo.profileImg || pickProfileImage(userInfo);
-      addRecentSearch(username, img, userInfo.nickname); // ✅ 이미지/닉네임 저장
+      addRecentSearch(username, img, userInfo.nickname); 
       setRecentSearches(getRecentSearchesWithMeta());
 
       const friend: Friend = {
@@ -121,7 +120,7 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
       return;
     }
 
-    // 최근 검색에서 온 경우 → 서버 재조회
+    
     try {
       const data = await searchFriends(username);
       const found: FriendSearchItem | undefined = data.result.members.contents.find(
@@ -134,7 +133,7 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
       }
 
       const img = found.profileImg || pickProfileImage(found);
-      addRecentSearch(found.username, img, found.nickname); // ✅ 메타 갱신
+      addRecentSearch(found.username, img, found.nickname); 
       setRecentSearches(getRecentSearchesWithMeta());
 
       const friend: Friend = {
@@ -188,7 +187,6 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
                   key={friend.username}
                   name={friend.nickname}
                   username={friend.username}
-                  // ✅ 검색 결과: 서버가 주는 profileImg 우선 사용, 없으면 보정
                   image={friend.profileImg || pickProfileImage(friend)}
                   onClick={() => handleSelectFriend(friend.username, friend)}
                   isSelected={selectedUsername === friend.username}
@@ -200,9 +198,9 @@ const FriendListPanel = ({ onSelect, selectedUsername }: FriendListPanelProps) =
                   key={item.username}
                   name={item.name ?? item.username}
                   username={item.username}
-                  // ✅ 저장된 이미지 그대로 표시 (없으면 빈 문자열 → 컴포넌트에서 기본아바타)
+                  //  저장된 이미지 그대로 표시 (없으면 빈 문자열 → 컴포넌트에서 기본아바타)
                   image={item.image ?? ""}
-                  onClick={() => handleSelectFriend(item.username)} // ✅ 재조회 트리거
+                  onClick={() => handleSelectFriend(item.username)} 
                   isSelected={selectedUsername === item.username}
                   showDelete
                   onDelete={() => handleRemoveRecent(item.username)}

--- a/src/utils/types/recentSearch.ts
+++ b/src/utils/types/recentSearch.ts
@@ -1,15 +1,12 @@
-// src/utils/types/recentSearch.ts
-
 const RECENT_SEARCH_KEY = "recentSearches";
 
-// V2 저장 포맷: 메타 포함
 export interface RecentSearch {
   username: string;
-  image?: string | null; // 프로필 이미지 URL
-  name?: string;         // 닉네임(옵션)
+  image?: string | null; 
+  name?: string;         
 }
 
-// 내부: 저장
+
 function saveRaw(items: RecentSearch[]) {
   try {
     localStorage.setItem(RECENT_SEARCH_KEY, JSON.stringify(items));
@@ -18,7 +15,7 @@ function saveRaw(items: RecentSearch[]) {
   }
 }
 
-// 내부: 읽기 + 레거시(string[]) 마이그레이션
+
 function readRaw(): RecentSearch[] {
   try {
     const raw = localStorage.getItem(RECENT_SEARCH_KEY);
@@ -26,12 +23,12 @@ function readRaw(): RecentSearch[] {
 
     const parsed = JSON.parse(raw);
 
-    // 1) 이미 객체 배열인 경우 -> 정상화
+    
     if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === "object") {
       const normalized: RecentSearch[] = parsed
         .map((v: any) => ({
           username: String(v?.username ?? ""),
-          // ✅ 백엔드 스펙 대응: profileImg 우선 포함
+          
           image:
             v?.image ??
             v?.profileImg ??
@@ -43,19 +40,19 @@ function readRaw(): RecentSearch[] {
         }))
         .filter((v) => v.username);
 
-      // 혹시 잘못 저장된 값이 섞였으면 정상화본으로 다시 저장
+     
       saveRaw(normalized);
       return normalized;
     }
 
-    // 2) 레거시(string[]) → 객체 배열로 마이그레이션
+    
     if (Array.isArray(parsed) && (parsed.length === 0 || typeof parsed[0] === "string")) {
       const migrated: RecentSearch[] = (parsed as string[]).map((username) => ({ username }));
       saveRaw(migrated);
       return migrated;
     }
 
-    // 그 외 형태면 초기화
+    
     return [];
   } catch (e) {
     console.warn("recentSearches 파싱 실패:", e);
@@ -63,35 +60,35 @@ function readRaw(): RecentSearch[] {
   }
 }
 
-/** ✅ 기존 API 유지: usernames만 반환 (호환성 유지) */
+
 export const getRecentSearches = (): string[] => {
   return readRaw().map((item) => item.username);
 };
 
-/** ✅ 메타 포함 버전: 이미지/닉네임까지 반환 */
+
 export const getRecentSearchesWithMeta = (): RecentSearch[] => {
   return readRaw();
 };
 
-/** ✅ 추가: 이미지/닉네임까지 함께 저장 (기존 사용법도 그대로 동작) */
+
 export const addRecentSearch = (username: string, image?: string | null, name?: string) => {
   if (!username) return;
 
   let items = readRaw();
 
-  // 중복 제거
+  
   items = items.filter((it) => it.username !== username);
 
-  // 맨 앞에 추가
+  
   items.unshift({ username, image: image ?? null, name });
 
-  // 최대 10개 제한
+
   if (items.length > 10) items = items.slice(0, 10);
 
   saveRaw(items);
 };
 
-/** ✅ username의 메타만 갱신 */
+
 export const updateRecentSearchMeta = (
   username: string,
   image?: string | null,
@@ -111,13 +108,13 @@ export const updateRecentSearchMeta = (
   saveRaw(items);
 };
 
-/** ✅ 기존 API 유지 */
+
 export const removeRecentSearch = (username: string) => {
   const items = readRaw().filter((it) => it.username !== username);
   saveRaw(items);
 };
 
-/** ✅ 기존 API 유지 */
+
 export const clearRecentSearches = () => {
   localStorage.removeItem(RECENT_SEARCH_KEY);
 };

--- a/src/utils/types/recentSearch.ts
+++ b/src/utils/types/recentSearch.ts
@@ -1,34 +1,123 @@
+// src/utils/types/recentSearch.ts
+
 const RECENT_SEARCH_KEY = "recentSearches";
 
-// 최근 검색 목록 가져오기
-export const getRecentSearches = (): string[] => {
-  const saved = localStorage.getItem(RECENT_SEARCH_KEY);
-  return saved ? JSON.parse(saved) : [];
-};
+// V2 저장 포맷: 메타 포함
+export interface RecentSearch {
+  username: string;
+  image?: string | null; // 프로필 이미지 URL
+  name?: string;         // 닉네임(옵션)
+}
 
-// 최근 검색 추가
-export const addRecentSearch = (username: string) => {
-  let searches = getRecentSearches();
-
-  // 중복 제거 후 맨 앞에 추가
-  searches = searches.filter((item) => item !== username);
-  searches.unshift(username);
-
-  // 최대 10개까지만 저장
-  if (searches.length > 10) {
-    searches = searches.slice(0, 10);
+// 내부: 저장
+function saveRaw(items: RecentSearch[]) {
+  try {
+    localStorage.setItem(RECENT_SEARCH_KEY, JSON.stringify(items));
+  } catch (e) {
+    console.warn("recentSearches 저장 실패:", e);
   }
+}
 
-  localStorage.setItem(RECENT_SEARCH_KEY, JSON.stringify(searches));
+// 내부: 읽기 + 레거시(string[]) 마이그레이션
+function readRaw(): RecentSearch[] {
+  try {
+    const raw = localStorage.getItem(RECENT_SEARCH_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw);
+
+    // 1) 이미 객체 배열인 경우 -> 정상화
+    if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === "object") {
+      const normalized: RecentSearch[] = parsed
+        .map((v: any) => ({
+          username: String(v?.username ?? ""),
+          // ✅ 백엔드 스펙 대응: profileImg 우선 포함
+          image:
+            v?.image ??
+            v?.profileImg ??
+            v?.profileImage ??
+            v?.profileImageUrl ??
+            v?.profileUrl ??
+            null,
+          name: v?.name ?? v?.nickname ?? undefined,
+        }))
+        .filter((v) => v.username);
+
+      // 혹시 잘못 저장된 값이 섞였으면 정상화본으로 다시 저장
+      saveRaw(normalized);
+      return normalized;
+    }
+
+    // 2) 레거시(string[]) → 객체 배열로 마이그레이션
+    if (Array.isArray(parsed) && (parsed.length === 0 || typeof parsed[0] === "string")) {
+      const migrated: RecentSearch[] = (parsed as string[]).map((username) => ({ username }));
+      saveRaw(migrated);
+      return migrated;
+    }
+
+    // 그 외 형태면 초기화
+    return [];
+  } catch (e) {
+    console.warn("recentSearches 파싱 실패:", e);
+    return [];
+  }
+}
+
+/** ✅ 기존 API 유지: usernames만 반환 (호환성 유지) */
+export const getRecentSearches = (): string[] => {
+  return readRaw().map((item) => item.username);
 };
 
-// 특정 검색어 삭제
+/** ✅ 메타 포함 버전: 이미지/닉네임까지 반환 */
+export const getRecentSearchesWithMeta = (): RecentSearch[] => {
+  return readRaw();
+};
+
+/** ✅ 추가: 이미지/닉네임까지 함께 저장 (기존 사용법도 그대로 동작) */
+export const addRecentSearch = (username: string, image?: string | null, name?: string) => {
+  if (!username) return;
+
+  let items = readRaw();
+
+  // 중복 제거
+  items = items.filter((it) => it.username !== username);
+
+  // 맨 앞에 추가
+  items.unshift({ username, image: image ?? null, name });
+
+  // 최대 10개 제한
+  if (items.length > 10) items = items.slice(0, 10);
+
+  saveRaw(items);
+};
+
+/** ✅ username의 메타만 갱신 */
+export const updateRecentSearchMeta = (
+  username: string,
+  image?: string | null,
+  name?: string,
+) => {
+  if (!username) return;
+  const items = readRaw();
+  const idx = items.findIndex((it) => it.username === username);
+  if (idx === -1) return;
+
+  items[idx] = {
+    ...items[idx],
+    image: image ?? items[idx].image ?? null,
+    name: name ?? items[idx].name,
+  };
+
+  saveRaw(items);
+};
+
+/** ✅ 기존 API 유지 */
 export const removeRecentSearch = (username: string) => {
-  const updated = getRecentSearches().filter((item) => item !== username);
-  localStorage.setItem(RECENT_SEARCH_KEY, JSON.stringify(updated));
+  const items = readRaw().filter((it) => it.username !== username);
+  saveRaw(items);
 };
 
-// 전체 삭제
+/** ✅ 기존 API 유지 */
 export const clearRecentSearches = () => {
   localStorage.removeItem(RECENT_SEARCH_KEY);
 };


### PR DESCRIPTION
기존 recentSearches는 string[] (username만) 저장 → 이미지/닉네임 정보가 없어 최근검색 목록에서 맨 위 항목만 실제 프로필이 보이는 현상 발생(새 포맷으로 저장된 것만 보임).

변경 사항
src/utils/types/recentSearch.ts
V2 포맷 도입: RecentSearch { username, image?, name? }
레거시 string[] → 객체 배열 자동 마이그레이션
addRecentSearch(username, image?, name?)로 메타 저장 지원
getRecentSearchesWithMeta() 추가(메타 포함 조회)
updateRecentSearchMeta(username, image?, name?) 추가(개별 보정)
readRaw() 정규화 시 백엔드 키 호환: profileImg 우선, 없으면 profileImage* / profileUrl 등 폴백

src/components/Friends/FriendListPanel.tsx
최근검색 로드시 getRecentSearchesWithMeta() 사용 → 저장된 이미지 즉시 표시
검색 결과 클릭 시 addRecentSearch(username, image, nickname)로 이미지/닉네임 함께 저장
마운트 시 이미지가 비어있는 항목만 서버 searchFriends 재조회하여 메타 백필(한 번만 수행)
렌더링: 검색 결과는 profileImg || pickProfileImage(), 최근검색은 저장된 item.image 우선 사용

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
