### PR TITLE
hotfix: access to signup

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -62,6 +62,14 @@ axiosInstance.interceptors.request.use(
 axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
+    const { pathname } = window.location;
+
+    // ✅ Skip token refresh on all public auth pages
+    if (pathname.startsWith("/home/")) {
+      // console.log("⏳ Skipped token refresh — on /home/*");
+      return;
+    }
+
     const originalRequest: CustomInternalAxiosRequestConfig = error.config;
 
     if (
@@ -80,8 +88,15 @@ axiosInstance.interceptors.response.use(
 );
 
 initActivityListeners();
-
 setInterval(() => {
+  const { pathname } = window.location;
+
+  // ✅ Skip token refresh on all public auth pages
+  if (pathname === "/home" || pathname.startsWith("/home/")) {
+    // console.log("⏳ Skipped token refresh — on /home/*");
+    return;
+  }
+
   const isActive = wasRecentlyActive();
 
   if (isActive) {


### PR DESCRIPTION
## 개요


https://github.com/user-attachments/assets/449b6fc1-70b2-4a46-8a1a-15e6e194d1bc

signup페이지로 접근하면 바로 login으로 돌아가는 현상이 발생함 
이유 : home, home/signup페이지에서 알 수 없는 api request가 이루어 지는데 여기서 발생한 에러를 axios interecept가 가로 채어 권한이 없다 -> accessToken이 만료되었다로 판단하여 강제로 home으로 redirect시키는 결과를 초래함. 

-> url이 "/home"으로 시작하는 부분에서는 해당 로직이 진행되지 않도록 조건문 설정

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
